### PR TITLE
Update amm_liquidity table definition

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,12 +2,11 @@
 CREATE TABLE public.amm_liquidity (
     timestamp bigint NOT NULL,
     dex character varying NOT NULL, 
-    pair character varying NOT NULL,
     market_address character varying NOT NULL,
-    token_x bigint NOT NULL, 
-    token_y bigint NOT NULL,
-    token_x_decimals int NOT NULL, 
-    token_y_decimals int NOT NULL,
+    token_x_amount bigint NOT NULL, 
+    token_y_amount bigint NOT NULL,
+    token_x_address character varying NOT NULL,
+    token_x_address character varying NOT NULL,
     additional_info character varying NOT NULL
 );
 
@@ -63,7 +62,7 @@ ALTER TABLE
     ONLY public.amm_liquidity
 ADD 
     CONSTRAINT amm_liquidity_pkey 
-    PRIMARY KEY (dex, pair, market_address, timestamp);
+    PRIMARY KEY (dex, token_x_address, token_y_address, market_address, timestamp);
 
 ALTER TABLE
     ONLY public.tx_signatures


### PR DESCRIPTION
Ditching `pair` and `decimals`: `pair` isn't really reliable and will be constructed based on the underlying tokens addresses. Since we'll most likely will be fetching the data somewhere then we might as well ditch decimals. Also changed `token_x` and `token_y` to  `token_x_amount` and  `token_y_amount` to prevent any confusion.